### PR TITLE
Fix transaction data race.

### DIFF
--- a/core/phase.go
+++ b/core/phase.go
@@ -85,7 +85,7 @@ func triggerPhaseRestart(r *http.Request) response {
 	messagingService := messaging.GetService()
 	phaseService := phase.GetService()
 	ticketService := ticket.GetService()
-	go startPhase(dataClient, codeService, messagingService, phaseService, ticketService, replacedPhase, authedUser)
+	go startPhase(data.NewClient(), codeService, messagingService, phaseService, ticketService, replacedPhase, authedUser)
 
 	return emptyResponse()
 }
@@ -276,7 +276,7 @@ func checkPhaseCompletion(
 			// Otherwise, the train isn't fully verified yet.
 			messagingService.TrainVerified(train)
 		}
-		go deployIfReady(dataClient, messagingService, train)
+		go deployIfReady(data.NewClient(), messagingService, train)
 	case types.Deploy:
 		err = dataClient.DeployTrain(train)
 		if err != nil {
@@ -299,7 +299,7 @@ func checkPhaseCompletion(
 
 			// Now that this train's deploy is finished,
 			// check if the latest train can be deployed.
-			go deployIfReady(dataClient, messagingService, latestTrain)
+			go deployIfReady(data.NewClient(), messagingService, latestTrain)
 		}
 	}
 }

--- a/core/train.go
+++ b/core/train.go
@@ -130,7 +130,7 @@ func handleNewCommitsForBranch(
 	}
 
 	if train != nil {
-		go StartTrain(dataClient, codeService, messagingService, phaseService, ticketService, train)
+		go StartTrain(data.NewClient(), codeService, messagingService, phaseService, ticketService, train)
 	}
 }
 
@@ -664,7 +664,7 @@ func cancelTrain(r *http.Request) response {
 
 		// Now that this train is cancelled,
 		// check if the latest train can be deployed.
-		go deployIfReady(dataClient, messagingService, latestTrain)
+		go deployIfReady(data.NewClient(), messagingService, latestTrain)
 	}
 
 	clearLatestTrainCache()


### PR DESCRIPTION
We would occasionally see broken transactions and broken db connections after running for some time.

After much digging and experimenting, it turns out that this pathological case happens when a db connection is shared between goroutines, and that db connection is running a transaction on one as the other goroutine performs other queries.

Obviously, we shouldn't do that!

Change all places where we invoke a goroutine and pass along a data client to create a new data client (and thus, a new connection).

Most of these places are actually fine as they do not use the data client themselves after creating the goroutine, except for one code path:

startPhase -> checkBranch -> handleNewCommitsForBranch -> go StartTrain() -> ...

For simplicity, whenever we create a goroutine, we should create a new data client.