### PR TITLE
Extension race condition fix, messaging improvements, and minor fixes.

### DIFF
--- a/core/phase.go
+++ b/core/phase.go
@@ -176,7 +176,10 @@ func phaseGroupDelivered(
 		if err != nil {
 			return err
 		}
-		train.Tickets = tickets
+
+		// Add these tickets to the train for anything that'll immediate check them.
+		// There might be existing tickets, so append first.
+		train.Tickets = append(train.Tickets, tickets...)
 	}
 
 	var newCommits []*types.Commit
@@ -218,7 +221,7 @@ func checkPhaseCompletion(
 		targetPhase.Type, targetPhase.Jobs.CompletedNames(), extraChecks...)
 
 	logger.Info("Checking phase completion for phase %v, train %v (%v). "+
-		"It has %v tickets, which will trigger %v extra completion checks.\n\nTrain: %+v",
+		"It has %d tickets, which will trigger %d extra completion checks.\n\nTrain: %+v",
 		targetPhase.Type, train.ID, train.HeadSHA, len(train.Tickets), len(extraChecks), train)
 
 	if phaseCompletedPreviously && phaseCurrentlyCompleted {
@@ -261,14 +264,14 @@ func checkPhaseCompletion(
 	}
 
 	logger.Info("Phase %s was completed for train %v (%s). "+
-		"It had %s tickets causing %s extra checks.\n\n%+v",
+		"It had %d tickets causing %d extra checks.\n\n%+v",
 		targetPhase.Type, train.ID, train.HeadSHA, len(train.Tickets), len(extraChecks), train)
 
 	// Post-phase actions
 	switch targetPhase.Type {
 	case types.Delivery:
 		go startPhase(
-			dataClient, codeService, messagingService, phaseService, ticketService,
+			data.NewClient(), codeService, messagingService, phaseService, ticketService,
 			targetPhase.PhaseGroup.Verification, nil)
 	case types.Verification:
 		if targetPhase.IsInActivePhaseGroup() {

--- a/core/phase_test.go
+++ b/core/phase_test.go
@@ -259,13 +259,13 @@ func TestDeliveryFinishedMessaging(t *testing.T) {
 	}
 	phaseService := &phase.PhaseServiceMock{}
 	codeService := &code.CodeServiceMock{}
+	assert.Equal(t, 2, len(train.Tickets))
 	startPhase(
 		dataClient, codeService, messagingService, phaseService, ticketService,
 		train.ActivePhases.Verification, user)
 	assert.Equal(t, 1, len(createTicketsCalls))
 	assert.Equal(t, createTicketsCalls[0].train, train)
-	assert.Equal(t, 1, len(createTicketsCalls))
-	assert.Equal(t, createTicketsCalls[0].train, train)
+	assert.Equal(t, 3, len(train.Tickets))
 
 	// Ensure tickets are created for the right commits - no-verify commits,
 	// and commits with pre-existing tickets - are excluded.

--- a/core/train.go
+++ b/core/train.go
@@ -545,7 +545,7 @@ func extendTrain(r *http.Request) response {
 	err = dataClient.CloseTrain(train, scheduleOverride)
 	if err != nil {
 		return errorResponse(
-			fmt.Sprintf("Error locking train: %v", err),
+			fmt.Sprintf("Error closing train: %v", err),
 			http.StatusInternalServerError)
 	}
 

--- a/services/data/methods.go
+++ b/services/data/methods.go
@@ -996,7 +996,6 @@ func (d *dataClient) WriteTickets(tickets []*types.Ticket) error {
 		for _, commit := range ticketCommits {
 			_, err = m2m.Add(commit)
 			if err != nil {
-				d.Client.Rollback()
 				return err
 			}
 		}

--- a/services/messaging/messaging.go
+++ b/services/messaging/messaging.go
@@ -86,9 +86,9 @@ func (m Messenger) TrainCreation(train *types.Train, commits []*types.Commit) {
 
 func (m Messenger) TrainExtension(train *types.Train, commits []*types.Commit, user *types.User) {
 	commitSets := m.commitSetsFromCommits(commits, true)
-	if len(commitSets) == 0 {
-		return
-	}
+	// Note: We used to abort early if there are no commit sets to notify for.
+	// Even if no commit sets, send train extension message for manual extensions.
+	// If all the changes are no-verify, we still want to notify the staging room.
 
 	trainLink := m.formatTrainLink(train, "Train extended")
 	if user != nil {


### PR DESCRIPTION
Fixes:

---

1. Fix a race condition on extension, which occurred when the following conditions were met:

- There were existing tickets on the train.
- An extension was performed.
- The train was closed.
- There were no new tickets created in the extension.
- The jobs for the verification phase were completed prior to the delivery phase.

We were overriding train.Tickets after verification phase completion.

This would cause the train to deploy early if the verification phase was also immediately completed, because the train wasn't reloaded from the database in the subsequently executed checkPhaseCompletion call which gets passed the same train object.

Instead, we should append the new tickets to train.Tickets.

---

2. Always message the slack channel about manual extensions, even if there are no new tickets to be created. This feedback is important for people to know that the extension worked okay.

---

3. Fix some types in the log statements.

---

4. Pass new dataClient in go routine. This is the last instance of this. This one wasn't explicitly causing any issues due to the surrounding code not opening any transactions, but it's still good to fix it for correctness.

---

5. Remove a transaction.Rollback call in a function that doesn't open a transaction. I believe this would cause a panic if we ever ran into it.