### PR TITLE
Only load AllPhaseGroups when needed.

### DIFF
--- a/core/phase.go
+++ b/core/phase.go
@@ -183,6 +183,11 @@ func phaseGroupDelivered(
 		train.Tickets = append(train.Tickets, tickets...)
 	}
 
+	err = dataClient.LoadLastDeliveredSHA(train)
+	if err != nil {
+		return err
+	}
+
 	var newCommits []*types.Commit
 	if train.LastDeliveredSHA == nil {
 		newCommits = train.CommitsSince(phaseGroup.HeadSHA)

--- a/core/train.go
+++ b/core/train.go
@@ -401,6 +401,16 @@ func fetchTrain(r *http.Request) response {
 		return *resp
 	}
 
+	if train != nil {
+		// The client uses LastDeliveredSha.
+		err := dataClient.LoadLastDeliveredSHA(train)
+		if err != nil {
+			return errorResponse(
+				fmt.Sprintf("Error fetching train: %v", err),
+				http.StatusInternalServerError)
+		}
+	}
+
 	return dataResponse(train)
 }
 

--- a/services/data/data.go
+++ b/services/data/data.go
@@ -44,6 +44,7 @@ type Client interface {
 	UnblockTrain(*types.Train) error
 	DeployTrain(*types.Train) error
 	CancelTrain(*types.Train) error
+	LoadLastDeliveredSHA(*types.Train) error
 
 	Phase(uint64, *types.Train) (*types.Phase, error)
 	StartPhase(*types.Phase) error


### PR DESCRIPTION
Most places do not use all phase groups, but it's an expensive query.

Only retrieve it when necessary (/api/train and the job API).