### PR TITLE
Add Datadog logging.

### DIFF
--- a/core/phase.go
+++ b/core/phase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Nextdoor/conductor/services/messaging"
 	"github.com/Nextdoor/conductor/services/phase"
 	"github.com/Nextdoor/conductor/services/ticket"
+	"github.com/Nextdoor/conductor/shared/datadog"
 	"github.com/Nextdoor/conductor/shared/logger"
 	"github.com/Nextdoor/conductor/shared/types"
 )
@@ -269,6 +270,13 @@ func checkPhaseCompletion(
 		return
 	}
 
+	tags := train.DatadogTags()
+	tags = append(tags, fmt.Sprintf("phase_name:%s", targetPhase.Type.String()))
+
+	datadog.Incr("phase.complete", tags)
+	duration := targetPhase.CompletedAt.Value.Sub(targetPhase.StartedAt.Value)
+	datadog.Gauge("phase.duration", duration.Seconds(), tags)
+
 	logger.Info("Phase %s was completed for train %v (%s). "+
 		"It had %d tickets causing %d extra checks.\n\n%+v",
 		targetPhase.Type, train.ID, train.HeadSHA, len(train.Tickets), len(extraChecks), train)
@@ -292,6 +300,21 @@ func checkPhaseCompletion(
 			logger.Error("Error deploying train: %v", err)
 			return
 		}
+
+		duration := train.DeployedAt.Value.Sub(train.CreatedAt.Value)
+
+		options, err := dataClient.Options()
+		if err != nil {
+			logger.Error("Error getting options: %v", err)
+			return
+		}
+
+		regularHoursDuration := options.CloseTimeOverlap(train.DeployedAt.Value, train.CreatedAt.Value)
+		afterHoursDuration := duration - regularHoursDuration
+
+		datadog.Gauge("train.deploy.lifetime.all_hours", duration.Seconds(), train.DatadogTags())
+		datadog.Gauge("train.deploy.lifetime.regular_hours", regularHoursDuration.Seconds(), train.DatadogTags())
+		datadog.Gauge("train.deploy.lifetime.after_hours", afterHoursDuration.Seconds(), train.DatadogTags())
 
 		messagingService.TrainDeployed(train)
 

--- a/core/ticket.go
+++ b/core/ticket.go
@@ -73,7 +73,9 @@ func syncTickets(
 		return
 	}
 
-	datadog.Count("ticket.count", len(newTickets), latestTrain.DatadogTags())
+	if len(newTickets) > 0 {
+		datadog.Count("ticket.count", len(newTickets), latestTrain.DatadogTags())
+	}
 	for _, updatedTicket := range updatedTickets {
 		if updatedTicket.ClosedAt.HasValue() || updatedTicket.DeletedAt.HasValue() {
 			var finished time.Time

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: b5d9e40e7460b465d299116019c7e60d9e1d479d541e205cf0b78a3a44164b74
-updated: 2019-04-24T12:01:50.057161-07:00
+updated: 2019-05-03T14:30:52.293876-07:00
 imports:
 - name: github.com/astaxie/beego
   version: f16688817aa428d10361394015b40d096b680542
   subpackages:
   - orm
 - name: github.com/DataDog/datadog-go
-  version: e67964b4021ad3a334e748e8811eb3cd6becbc6e
+  version: 8a13fa761f51039f900738876f2837198fba804f
   subpackages:
   - statsd
 - name: github.com/fatih/structs
@@ -34,7 +34,7 @@ imports:
 - name: github.com/Nextdoor/go-jira
   version: 1c43ea14716de91dc78aa4dd38b4a6b81cabf829
 - name: github.com/nlopes/slack
-  version: 6519657c021b7add19c4ef48220140cca0b1657b
+  version: 65ea2b979a7ffe628676bdb6b924e2498d66c1bf
 - name: github.com/pkg/errors
   version: 27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7
 - name: github.com/satori/go.uuid

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
 - package: github.com/xeipuuv/gojsonschema
 - package: golang.org/x/oauth2
 - package: github.com/DataDog/datadog-go
-  version: 2.1.0
+  version: 2.2.0
   subpackages:
   - statsd
 testImport:

--- a/resources/decrypt_secrets.sh
+++ b/resources/decrypt_secrets.sh
@@ -1,0 +1,32 @@
+# Decrypts secrets. Should be sourced.
+
+# Helper to decrypt KMS blobs
+kms_decrypt () {
+    set -e
+    local ENCRYPTED=$1
+    local BLOB_PATH=$(mktemp)
+    echo $ENCRYPTED | base64 --decode > $BLOB_PATH
+    aws kms decrypt --ciphertext-blob fileb://$BLOB_PATH --output text --query Plaintext | base64 --decode
+    rm -f $BLOB_PATH
+}
+
+SECRETS="GITHUB_ADMIN_TOKEN GITHUB_AUTH_CLIENT_SECRET GITHUB_WEBHOOK_SECRET JENKINS_PASSWORD SLACK_TOKEN JIRA_API_TOKEN"
+# Try to decrypt the various KMS blobs, if they're set.
+touch /tmp/secrets
+for SECRET in $SECRETS; do
+    BLOB_NAME="${SECRET}_BLOB"
+    if [[ -n "${!BLOB_NAME}" ]]; then
+        (
+            echo "Decoding ${BLOB_NAME}."
+            DECRYPTED=$(kms_decrypt "${!BLOB_NAME}")
+            echo "${SECRET}='${DECRYPTED}'" >> /tmp/secrets
+        ) &
+    fi
+done
+
+wait
+
+set -a
+source /tmp/secrets
+set +a
+rm -rf /tmp/secrets

--- a/setup.sh
+++ b/setup.sh
@@ -21,6 +21,11 @@ setup_data() {
         exit 1
     fi
 
+    touch envfile
+    set -a
+    source envfile
+    set +a
+    source resources/decrypt_secrets.sh
     go run cmd/test_data.go -test_data_type $type
 }
 

--- a/shared/datadog/datadog_test.go
+++ b/shared/datadog/datadog_test.go
@@ -14,6 +14,8 @@ var sock, _ = net.ListenUDP("udp", addr)
 
 func TestLogInfo(t *testing.T) {
 	os.Setenv("STATSD_HOST", "localhost")
+	enableDatadog = true
+	c = newStatsdClient()
 	assert.NotNil(t, c)
 	log(statsd.Info, "%s testing", "conductor")
 	buf := make([]byte, 1024)
@@ -23,6 +25,8 @@ func TestLogInfo(t *testing.T) {
 
 func TestLogError(t *testing.T) {
 	os.Setenv("STATSD_HOST", "localhost")
+	enableDatadog = true
+	c = newStatsdClient()
 	assert.NotNil(t, c)
 	log(statsd.Error, "%s testing", "conductor")
 	buf := make([]byte, 1024)

--- a/shared/types/options.go
+++ b/shared/types/options.go
@@ -23,7 +23,7 @@ type Options struct {
 	//          EndTime: Clock{Hour: 17, Minute: 0},
 	//      },
 	//  }
-	CloseTime            []RepeatingTimeInterval `json:"close_time"`
+	CloseTime            RepeatingTimeIntervals  `json:"close_time"`
 	ValidationError      error                   `orm:"-" json:"-"`
 	InvalidOptionsString string                  `orm:"-" json:"-"`
 }
@@ -85,8 +85,12 @@ func (o Options) InCloseTime() bool {
 	return false
 }
 
+func (o Options) CloseTimeOverlap(start time.Time, end time.Time) time.Duration {
+	return o.CloseTime.TotalOverlap(start, end)
+}
+
 // Default is M-F 9-5. Hours are in UTC.
-var defaultCloseTime = []RepeatingTimeInterval{
+var defaultCloseTime = RepeatingTimeIntervals{
 	{
 		Every: []time.Weekday{
 			time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday},
@@ -95,7 +99,7 @@ var defaultCloseTime = []RepeatingTimeInterval{
 	},
 }
 
-var DefaultOptions Options = Options{CloseTime: defaultCloseTime}
+var DefaultOptions = Options{CloseTime: defaultCloseTime}
 
 // Used for JSON Schema validation.
 // Update this when the structure of Options changes.

--- a/shared/types/options.go
+++ b/shared/types/options.go
@@ -23,9 +23,9 @@ type Options struct {
 	//          EndTime: Clock{Hour: 17, Minute: 0},
 	//      },
 	//  }
-	CloseTime            RepeatingTimeIntervals  `json:"close_time"`
-	ValidationError      error                   `orm:"-" json:"-"`
-	InvalidOptionsString string                  `orm:"-" json:"-"`
+	CloseTime            RepeatingTimeIntervals `json:"close_time"`
+	ValidationError      error                  `orm:"-" json:"-"`
+	InvalidOptionsString string                 `orm:"-" json:"-"`
 }
 
 // Implement beego Fielder interface to handle serialization and deserialization.

--- a/shared/types/time.go
+++ b/shared/types/time.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"sort"
 	"time"
 )
 
@@ -14,9 +15,15 @@ type RepeatingTimeInterval struct {
 	EndTime   Clock          `json:"end_time"`
 }
 
+type RepeatingTimeIntervals []RepeatingTimeInterval
+
 type Clock struct {
 	Hour   int `json:"hour"`
 	Minute int `json:"minute"`
+}
+
+func (clock Clock) ToDuration() time.Duration {
+	return time.Hour*time.Duration(clock.Hour) + time.Minute*time.Duration(clock.Minute)
 }
 
 type Moment interface {
@@ -51,4 +58,182 @@ func (interval RepeatingTimeInterval) Includes(testTime Moment) bool {
 		}
 	}
 	return false
+}
+
+type Interval struct {
+	start time.Time
+	end   time.Time
+}
+
+func (interval Interval) WithDate(year int, month time.Month, day int) Interval {
+	return Interval{
+		start: time.Date(
+			year, month, day,
+			interval.start.Hour(), interval.start.Minute(),
+			0, 0, interval.start.Location()),
+		end: time.Date(
+			year, month, day,
+			interval.end.Hour(), interval.end.Minute(),
+			0, 0, interval.end.Location()),
+	}
+}
+
+type Intervals []Interval
+
+func (intervals Intervals) Len() int {
+	return len(intervals)
+}
+func (intervals Intervals) Swap(i, j int) {
+	intervals[i], intervals[j] = intervals[j], intervals[i]
+}
+func (intervals Intervals) Less(i, j int) bool {
+	return intervals[i].start.Sub(intervals[j].start) < 0
+}
+
+func (repeatingTimeIntervals RepeatingTimeIntervals) weekdayIntervals() map[time.Weekday][]Interval {
+	// Start by calculating the minimal set of intervals for the weekdays.
+	weekdayToInterval := make(map[time.Weekday][]Interval)
+	for weekday := time.Sunday; weekday <= time.Saturday; weekday++ {
+		intervals := make([]Interval, 0)
+		for _, interval := range repeatingTimeIntervals {
+			includesWeekday := false
+			for _, every := range interval.Every {
+				if every == weekday {
+					includesWeekday = true
+				}
+			}
+			if !includesWeekday {
+				continue
+			}
+
+			intervals = append(intervals, Interval{
+				start: time.Time{}.Add(interval.StartTime.ToDuration()),
+				end:   time.Time{}.Add(interval.EndTime.ToDuration())})
+		}
+
+		// Sort and merge intervals for the weekday.
+		// Sort by descending order of start time.
+		sort.Sort(sort.Reverse(Intervals(intervals)))
+
+		// Merge intervals as much as possible.
+		mergedIntervals := make([]Interval, 0)
+		mergedIntervalIndex := 0
+		for i, interval := range intervals {
+			if i == 0 {
+				mergedIntervals = append(mergedIntervals, interval)
+			} else {
+				previousInterval := mergedIntervals[i-1]
+				doesOverlap := interval.end.Sub(previousInterval.start) > 0
+				if doesOverlap {
+					previousEndsEarlier := interval.end.Sub(previousInterval.end) > 0
+					if previousEndsEarlier {
+						mergedIntervals[i-1] = interval
+					} else {
+						mergedIntervals[i-1] = Interval{
+							start: interval.start,
+							end:   previousInterval.end,
+						}
+					}
+				} else {
+					mergedIntervals = append(mergedIntervals, interval)
+					mergedIntervalIndex += 1
+				}
+			}
+		}
+
+		// Store this set of intervals on the weekday.
+		weekdayToInterval[weekday] = mergedIntervals
+	}
+
+	return weekdayToInterval
+}
+
+// Computes the time overlap between a specified array of intervals and
+// a specified start and end time.
+// Intervals must be sorted in descending order of start time.
+// Start and end times must be on the same date.
+// Start and end time are optional.
+// If start time is nil, start time is assumed the very beginning of the day.
+// If end time is nil, end time is assumed the very end of the day.
+func timeOverlap(intervals []Interval, start *time.Time, end *time.Time) time.Duration {
+	var year int
+	var month time.Month
+	var day int
+
+	if start != nil {
+		year, month, day = start.Date()
+	} else if end != nil {
+		year, month, day = end.Date()
+	}
+
+	var totalOverlap time.Duration = 0
+	for _, interval := range intervals {
+		datedInterval := interval.WithDate(year, month, day)
+		testStart := datedInterval.start
+		if start != nil && datedInterval.start.Sub(*start) < 0 {
+			testStart = *start
+		}
+		testEnd := datedInterval.end
+		if end != nil && datedInterval.end.Sub(*end) > 0 {
+			testEnd = *end
+		}
+		overlap := testEnd.Sub(testStart)
+		if overlap > 0 {
+			totalOverlap += overlap
+		}
+	}
+
+	return totalOverlap
+}
+
+// TotalOverlap calculates the total overlap duration between the specified start and end times.
+func (repeatingTimeIntervals RepeatingTimeIntervals) TotalOverlap(start time.Time, end time.Time) time.Duration {
+	if end.Sub(start) < 0 {
+		// End is before start, so no overlap.
+		return 0
+	}
+
+	weekdayToInterval := repeatingTimeIntervals.weekdayIntervals()
+	// Iterate through each day between start and end time and calculate totalOverlap, summing it all up.
+	//
+	// If the start time and the end time are the same date, the totalOverlap is:
+	//   `min(interval_end, end_time) - max(interval_start, start_time)` summed for each interval.
+	//
+	// Otherwise, the totalOverlap happens over multiple days.
+	// For the first day, the totalOverlap is `interval_end - max(interval_start, start_time)` summed for each interval.
+	// For the end day, the totalOverlap is `min(interval_end, end_time) - interval_start` summed for each interval.
+	// For all middle days, the totalOverlap is `interval_end - interval_start` summed for each interval.
+	var totalOverlap time.Duration = 0
+
+	startYear, startMonth, startDay := start.Date()
+	endYear, endMonth, endDay := end.Date()
+	if startYear == endYear && startMonth == endMonth && startDay == endDay {
+		// Start and end times are on the same date.
+		// Find the relevant day intervals.
+		totalOverlap += timeOverlap(weekdayToInterval[start.Weekday()], &start, &end)
+	} else {
+		// Start day.
+		totalOverlap += timeOverlap(weekdayToInterval[start.Weekday()], &start, nil)
+
+		// Middle days. Start one day ahead of start day, iterate through each day.
+		middleTime := time.Date(startYear, startMonth, startDay, 0, 0, 0, 0, start.Location())
+		middleTime = middleTime.AddDate(0, 0, 1)
+		for {
+			middleYear, middleMonth, middleDay := middleTime.Date()
+			if middleYear == endYear && middleMonth == endMonth && middleDay == endDay {
+				// On the end day.
+				break
+			}
+
+			totalOverlap += timeOverlap(weekdayToInterval[middleTime.Weekday()], nil, nil)
+
+			// Go forward one day.
+			middleTime = middleTime.AddDate(0, 0, 1)
+		}
+
+		// End day.
+		totalOverlap += timeOverlap(weekdayToInterval[end.Weekday()], nil, &end)
+	}
+
+	return totalOverlap
 }

--- a/shared/types/time_test.go
+++ b/shared/types/time_test.go
@@ -3,6 +3,8 @@ package types
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type TestTime struct {
@@ -133,4 +135,418 @@ func TestDifferentDayMatching(t *testing.T) {
 		t.Fatalf("%v was not detected as including %v.",
 			interval, testTime)
 	}
+}
+
+func TestWeekdayIntervalsSingle(t *testing.T) {
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Monday},
+			Clock{0, 0}, Clock{12, 0},
+		},
+	}
+
+	// Only Monday should have an interval.
+	weekdayToIntervals := intervals.weekdayIntervals()
+	assert.Len(t, weekdayToIntervals[time.Sunday], 0)
+	assert.Len(t, weekdayToIntervals[time.Monday], 1)
+	assert.Len(t, weekdayToIntervals[time.Tuesday], 0)
+	assert.Len(t, weekdayToIntervals[time.Wednesday], 0)
+	assert.Len(t, weekdayToIntervals[time.Thursday], 0)
+	assert.Len(t, weekdayToIntervals[time.Friday], 0)
+	assert.Len(t, weekdayToIntervals[time.Saturday], 0)
+
+	// Monday should be 0-12.
+	assert.Equal(t, Interval{
+		start: time.Time{},
+		end:   time.Time{}.Add(time.Hour * 12),
+	}, weekdayToIntervals[time.Monday][0])
+}
+
+func TestWeekdayIntervalsMultiplePerDay(t *testing.T) {
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Monday, time.Tuesday, time.Friday},
+			Clock{3, 0}, Clock{6, 0},
+		},
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{4, 0}, Clock{7, 0},
+		},
+		{
+			[]time.Weekday{time.Monday},
+			Clock{8, 0}, Clock{10, 30},
+		},
+	}
+
+	// Only Monday, Tuesday, and Friday should have intervals. Monday has 2.
+	weekdayToIntervals := intervals.weekdayIntervals()
+	assert.Len(t, weekdayToIntervals[time.Sunday], 0)
+	assert.Len(t, weekdayToIntervals[time.Monday], 2)
+	assert.Len(t, weekdayToIntervals[time.Tuesday], 1)
+	assert.Len(t, weekdayToIntervals[time.Wednesday], 0)
+	assert.Len(t, weekdayToIntervals[time.Thursday], 0)
+	assert.Len(t, weekdayToIntervals[time.Friday], 1)
+	assert.Len(t, weekdayToIntervals[time.Saturday], 0)
+
+	// Monday should be 3-6 and 8-10:30.
+	// In descending order of start time, so 8-10:30 first.
+	assert.Equal(t, Interval{
+		start: time.Time{}.Add(time.Hour * 8),
+		end:   time.Time{}.Add(time.Hour*10 + time.Minute*30),
+	}, weekdayToIntervals[time.Monday][0])
+	assert.Equal(t, Interval{
+		start: time.Time{}.Add(time.Hour * 3),
+		end:   time.Time{}.Add(time.Hour * 6),
+	}, weekdayToIntervals[time.Monday][1])
+
+	// Tuesday should be 3-7.
+	assert.Equal(t, Interval{
+		start: time.Time{}.Add(time.Hour * 3),
+		end:   time.Time{}.Add(time.Hour * 7),
+	}, weekdayToIntervals[time.Tuesday][0])
+
+	// Friday should be 3-6.
+	assert.Equal(t, Interval{
+		start: time.Time{}.Add(time.Hour * 3),
+		end:   time.Time{}.Add(time.Hour * 6),
+	}, weekdayToIntervals[time.Friday][0])
+}
+
+func TestWithDate(t *testing.T) {
+	interval := Interval{
+		start: time.Time{}.Add(time.Hour * 3),
+		end:   time.Time{}.Add(time.Hour * 6),
+	}
+
+	var year int
+	var month time.Month
+	var day int
+
+	var withDate Interval
+	withDate = interval.WithDate(2019, 12, 31)
+	year, month, day = withDate.start.Date()
+	assert.Equal(t, 2019, year)
+	assert.Equal(t, time.Month(12), month)
+	assert.Equal(t, 31, day)
+	year, month, day = withDate.end.Date()
+	assert.Equal(t, 2019, year)
+	assert.Equal(t, time.Month(12), month)
+	assert.Equal(t, 31, day)
+
+	// Should stay the same after doing WithDate again.
+	withDate = interval.WithDate(2019, 12, 31)
+	year, month, day = withDate.start.Date()
+	assert.Equal(t, 2019, year)
+	assert.Equal(t, time.Month(12), month)
+	assert.Equal(t, 31, day)
+	year, month, day = withDate.end.Date()
+	assert.Equal(t, 2019, year)
+	assert.Equal(t, time.Month(12), month)
+	assert.Equal(t, 31, day)
+}
+
+func TestTimeOverlapStartEnd(t *testing.T) {
+	// Test with an interval from 3-6:30 and 10-12.
+	intervals := []Interval{
+		{
+			start: time.Time{}.Add(time.Hour * 3),
+			end:   time.Time{}.Add(time.Hour*6 + time.Minute*30),
+		},
+		{
+			start: time.Time{}.Add(time.Hour * 10),
+			end:   time.Time{}.Add(time.Hour * 12),
+		},
+	}
+
+	// Get the overlap between those intervals and 4-11.
+	// Start and end must be at the same date. Let's try Dec 31st, 2019.
+	start := time.Date(2019, 12, 31, 4, 0, 0, 0, time.UTC)
+	end := time.Date(2019, 12, 31, 11, 0, 0, 0, time.UTC)
+
+	overlap := timeOverlap(intervals, &start, &end)
+	// The expected overlap is 2.5 hours for the first interval,
+	// and 1 hour for the second interval, so 3.5 hours.
+	assert.Equal(t, 3.5, overlap.Hours())
+}
+
+func TestTimeOverlapStart(t *testing.T) {
+	// Test with an interval from 3-6:30 and 10-12.
+	intervals := []Interval{
+		{
+			start: time.Time{}.Add(time.Hour * 3),
+			end:   time.Time{}.Add(time.Hour*6 + time.Minute*30),
+		},
+		{
+			start: time.Time{}.Add(time.Hour * 10),
+			end:   time.Time{}.Add(time.Hour * 12),
+		},
+	}
+
+	// Get the overlap between those intervals and 1 to end of day.
+	// Let's try Dec 31st, 2019.
+	start := time.Date(2019, 12, 31, 1, 0, 0, 0, time.UTC)
+
+	overlap := timeOverlap(intervals, &start, nil)
+	// The expected overlap is 3.5 hours for the first interval,
+	// and 2 hours for the second interval, so 5.5 hours.
+	assert.Equal(t, 5.5, overlap.Hours())
+}
+
+func TestTimeOverlapEnd(t *testing.T) {
+	// Test with an interval from 3-6:30 and 10-12.
+	intervals := []Interval{
+		{
+			start: time.Time{}.Add(time.Hour * 3),
+			end:   time.Time{}.Add(time.Hour*6 + time.Minute*30),
+		},
+		{
+			start: time.Time{}.Add(time.Hour * 10),
+			end:   time.Time{}.Add(time.Hour * 12),
+		},
+	}
+
+	// Get the overlap between those intervals and start of day to 11.
+	// Let's try Dec 31st, 2019.
+	end := time.Date(2019, 12, 31, 11, 0, 0, 0, time.UTC)
+
+	overlap := timeOverlap(intervals, nil, &end)
+	// The expected overlap is 3.5 hours for the first interval,
+	// and 1 hour for the second interval, so 4.5 hours.
+	assert.Equal(t, 4.5, overlap.Hours())
+}
+
+func TestTotalOverlapSingleDayNoIntervals(t *testing.T) {
+	intervals := RepeatingTimeIntervals{}
+
+	// Let's start from Dec 31st, 2019, so it rolls over a year.
+	// Dec 31st, 2019 is a Tuesday.
+	start := time.Date(2019, 12, 31, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2019, 12, 31, 24, 0, 0, 0, time.UTC)
+
+	// With no intervals, the overlap should be 0.
+	overlap := intervals.TotalOverlap(start, end)
+	assert.Equal(t, 0.0, overlap.Hours())
+}
+
+func TestTotalOverlapSingleDayWrongDayOfWeek(t *testing.T) {
+	// 0-3, 6-9 on a Tuesday.
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Monday},
+			Clock{0, 0}, Clock{3, 0},
+		},
+		{
+			[]time.Weekday{time.Monday},
+			Clock{6, 0}, Clock{9, 0},
+		},
+	}
+
+	// Let's start from Dec 31st, 2019, so it rolls over a year.
+	// Dec 31st, 2019 is a Tuesday.
+	start := time.Date(2019, 12, 31, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2019, 12, 31, 24, 0, 0, 0, time.UTC)
+
+	// With no intervals on Tuesday, the total should be 0.
+	overlap := intervals.TotalOverlap(start, end)
+	assert.Equal(t, 0.0, overlap.Hours())
+}
+
+func TestTotalOverlapSingleDay(t *testing.T) {
+	// 0-3, 6-9 on a Tuesday.
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{0, 0}, Clock{3, 0},
+		},
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{6, 0}, Clock{9, 0},
+		},
+	}
+
+	// Let's start from Dec 31st, 2019, so it rolls over a year.
+	// Dec 31st, 2019 is a Tuesday.
+	start := time.Date(2019, 12, 31, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2019, 12, 31, 24, 0, 0, 0, time.UTC)
+
+	// With 0-3, 6-9 intervals, the overlap should be 6 hours total.
+	overlap := intervals.TotalOverlap(start, end)
+	assert.Equal(t, 6.0, overlap.Hours())
+}
+
+func TestTotalOverlapSingleDayPartial(t *testing.T) {
+	// 0-3, 6-9 on a Tuesday.
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{0, 0}, Clock{3, 0},
+		},
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{6, 0}, Clock{9, 0},
+		},
+	}
+
+	// Let's start from Dec 31st, 2019, so it rolls over a year.
+	// Dec 31st, 2019 is a Tuesday.
+	// Let's start from 2:15 and end at 7.
+	start := time.Date(2019, 12, 31, 2, 15, 0, 0, time.UTC)
+	end := time.Date(2019, 12, 31, 7, 0, 0, 0, time.UTC)
+
+	// With 0-3, 6-9 intervals, the overlap should be 45 minutes + 1 hour,
+	// for 1 hour 45 minutes total.
+	overlap := intervals.TotalOverlap(start, end)
+	assert.Equal(t, 1.75, overlap.Hours())
+}
+
+func TestTotalOverlapTwoDay(t *testing.T) {
+	// 0-3, 6-9 on a Tuesday, and 12-20:30 on Wednesday.
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{0, 0}, Clock{3, 0},
+		},
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{6, 0}, Clock{9, 0},
+		},
+		{
+			[]time.Weekday{time.Wednesday},
+			Clock{12, 0}, Clock{20, 30},
+		},
+	}
+
+	// Let's start from Dec 31st, 2019, so it rolls over a year.
+	// Dec 31st, 2019 is a Tuesday.
+	start := time.Date(2019, 12, 31, 0, 0, 0, 0, time.UTC)
+	// End goes 48 hours into the future.
+	end := time.Date(2019, 12, 31, 48, 0, 0, 0, time.UTC)
+
+	// With 0-3, 6-9 intervals, the overlap should be 6 hours total on Tuesday.
+	// With the 12-20:30 interval, the overlap should be 8.5 hours on Wednesday.
+	// The total overlap should be 14.5 hours.
+	overlap := intervals.TotalOverlap(start, end)
+	assert.Equal(t, 14.5, overlap.Hours())
+}
+
+func TestTotalOverlapTwoDayPartial(t *testing.T) {
+	// 0-3, 6-9 on a Tuesday, and 12-20:30 on Wednesday.
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{0, 0}, Clock{3, 0},
+		},
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{6, 0}, Clock{9, 0},
+		},
+		{
+			[]time.Weekday{time.Wednesday},
+			Clock{12, 0}, Clock{20, 30},
+		},
+	}
+
+	// Let's start from Dec 31st, 2019, so it rolls over a year.
+	// Dec 31st, 2019 is a Tuesday.
+	// Let's start at 2 (2am) on Tuesday.
+	start := time.Date(2019, 12, 31, 2, 0, 0, 0, time.UTC)
+	// Let's end at 17 (5pm) on Wednesday.
+	end := time.Date(2020, 1, 1, 17, 0, 0, 0, time.UTC)
+
+	// With 0-3, 6-9 intervals, the overlap should be 4 hours total on Tuesday.
+	// With the 12-20:30 interval, the overlap should be 5 hours on Wednesday.
+	// The total overlap should be 9 hours.
+	overlap := intervals.TotalOverlap(start, end)
+	assert.Equal(t, 9.0, overlap.Hours())
+}
+
+func TestTotalOverlapMultiday(t *testing.T) {
+	// 0-3, 6-9 on a Tuesday, 10-22 on Wednesday, 0-12 on Thursday,
+	// and 12-20:30 on Friday.
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{0, 0}, Clock{3, 0},
+		},
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{6, 0}, Clock{9, 0},
+		},
+		{
+			[]time.Weekday{time.Wednesday},
+			Clock{10, 0}, Clock{22, 0},
+		},
+		{
+			[]time.Weekday{time.Thursday},
+			Clock{0, 0}, Clock{12, 0},
+		},
+		{
+			[]time.Weekday{time.Friday},
+			Clock{12, 0}, Clock{20, 30},
+		},
+	}
+
+	// Let's start from Dec 31st, 2019, so it rolls over a year.
+	// Dec 31st, 2019 is a Tuesday.
+	// Let's start at 2 (2am) on Tuesday.
+	start := time.Date(2019, 12, 31, 2, 0, 0, 0, time.UTC)
+	// Let's end at 17 (5pm) on Friday.
+	end := time.Date(2020, 1, 3, 17, 0, 0, 0, time.UTC)
+
+	// With 0-3, 6-9 intervals, the overlap should be 4 hours total on Tuesday.
+	// Wednesday and Thursday both have 12 hour intervals.
+	// With the 12-20:30 interval, the overlap should be 5 hours on Friday.
+	// The total overlap should be 33 hours.
+	overlap := intervals.TotalOverlap(start, end)
+	assert.Equal(t, 33.0, overlap.Hours())
+}
+
+func TestTotalOverlapMultimonth(t *testing.T) {
+	// 0-3, 6-9 on a Tuesday, 10-22 on Wednesday, 0-12 on Thursday,
+	// and 12-20:30 on Friday.
+	intervals := RepeatingTimeIntervals{
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{0, 0}, Clock{3, 0},
+		},
+		{
+			[]time.Weekday{time.Tuesday},
+			Clock{6, 0}, Clock{9, 0},
+		},
+		{
+			[]time.Weekday{time.Wednesday},
+			Clock{10, 0}, Clock{22, 0},
+		},
+		{
+			[]time.Weekday{time.Thursday},
+			Clock{0, 0}, Clock{12, 0},
+		},
+		{
+			[]time.Weekday{time.Friday},
+			Clock{12, 0}, Clock{20, 30},
+		},
+	}
+
+	// Let's start from Dec 31st, 2019, so it rolls over a year.
+	// Dec 31st, 2019 is a Tuesday.
+	// Let's start at 2 (2am) on Tuesday.
+	start := time.Date(2019, 12, 31, 2, 0, 0, 0, time.UTC)
+	// Let's end at 17 (5pm) on Friday, 10 weeks later.
+	end := time.Date(2020, 3, 6, 17, 0, 0, 0, time.UTC)
+
+	// The first Tuesday has a 4 hour overlap.
+	// The last Friday has a 5 hour overlap.
+	// Other Tuesdays have a 6 hour overlap.
+	// Wednesday and Thursdays have 12 hour overlaps.
+	// Other Fridays has a 8.5 hour overlap.
+
+	// Between 2019-12-31 and 2020-3-3, there are:
+	//  10 Tuesdays (4 hours + 9 * 6 hours).
+	//  10 Wednesdays (10 * 12 hours)
+	//  10 Thursdays (10 * 12 hours)
+	//  10 Fridays (9 * 8.5 hours + 5 hours)
+	// Total: 379.5 hours.
+
+	overlap := intervals.TotalOverlap(start, end)
+	assert.Equal(t, 379.5, overlap.Hours())
 }


### PR DESCRIPTION
Add Datadog logging.

# Adds metrics for:

## Train metrics

Tags: `train_id`

* `train.create` (count)
* `train.extend` (count)
* `train.duplicate` (count)
* `train.deploy` (count)
* `train.cancel` (count)
* `train.block` (count)
* `train.unblock` (count)
* `train.rollback` (count)
* `train.deploy.lifetime.all_hours` (gauge)
* `train.deploy.lifetime.regular_hours` (gauge)
* `train.deploy.lifetime.after_hours` (gauge)
* `train.cancel.lifetime.all_hours` (gauge)
* `train.cancel.lifetime.regular_hours` (gauge)
* `train.cancel.lifetime.after_hours` (gauge)

## Job metrics

Tags: `train_id`, `phase_name`, `job_name`

* `job.start` (count)
* `job.restart` (count)
* `job.complete` (count)
* `job.success` (count)
* `job.failure` (count)
* `job.duration` (gauge)
* `job.start.time_since_phase_start` (gauge)
* `job.complete.time_since_phase_start` (gauge)

## Phase metrics

Tags: `train_id`, `phase_name`

* `phase.complete` (count)
* `phase.duration` (gauge)

## Ticket metrics

Tags: `train_id`

* `ticket.count` (count)
* `ticket.duration` (gauge) (extra tag: `ticket_user`)

## Commit metrics

Tags: `train_id`

* `commit.count` (count)
* `commit.robot` (count)
* `commit.human` (count)
* `commit.needs_staging` (count)
* `commit.no_verify` (count)

# Other changes:

* Upgrades Slack to a version that supports paginating list of users.
* Upgrade Datadog API library to a newer version with a better interface.
