### PR TITLE
Updating deployment port and datadog config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ PGDATA=/var/lib/postgresql/data/conductor
 
 define PG_ARGS
 --name conductor-postgres \
---publish 5432:5432 \
+--publish 5434:5432 \
 --env POSTGRES_USER=$(PGUSER) \
 --env POSTGRES_PASSWORD=$(PGPASS) \
 --env POSTGRES_DB=$(PGDB) \
@@ -150,6 +150,8 @@ psql:
 
 test-data: postgres-wipe
 	export POSTGRES_HOST=localhost; \
+	export POSTGRES_PORT=5434; \
+	export ENABLE_DATADOG=false; \
 	set -a; \
 	if [[ -e testenv ]]; then \
 		source testenv; \


### PR DESCRIPTION
1) putting default postgres port as 5434 instead of 5432, prevents it from conflicting with other postgres instances running on local environment, and does not impact connection with go conductor service.
2) also for local development (test-postgres), we want the datadog to be turned off by default.