### PR TITLE
Update framework ver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,12 @@ RUN ls /app/swagger/
 RUN cd /app && pretty-swag -c /app/swagger/config.json
 
 # Add awscli
-RUN apt-get update && \
-    apt-get install -y \
-        python3 \
+RUN apt-get install -y \
         python3-pip \
-        python3-setuptools \
-        groff \
-        less \
-    && pip3 install --upgrade pip \
+    && pip3 --no-cache-dir install --upgrade awscli \
     && apt-get clean
 
-RUN pip3 --no-cache-dir install --upgrade awscli
+
 
 
 # Set up Go app.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,6 @@ RUN apt-get install -y \
     && pip3 --no-cache-dir install --upgrade awscli \
     && apt-get clean
 
-
-
-
 # Set up Go app.
 ADD .build /src/github.com/Nextdoor/conductor/
 ADD .build /go/src/github.com/Nextdoor/conductor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,17 @@ RUN ls /app/swagger/
 RUN cd /app && pretty-swag -c /app/swagger/config.json
 
 # Add awscli
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
-    pip install awscli && \
-    rm -f get-pip.py
+RUN apt-get update && \
+    apt-get install -y \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        groff \
+        less \
+    && pip3 install --upgrade pip \
+    && apt-get clean
+
+RUN pip3 --no-cache-dir install --upgrade awscli
 
 
 # Set up Go app.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Nextdoor/conductor
 
-go 1.12
+go 1.11.13
 
 require (
 	github.com/DataDog/datadog-go v2.2.0+incompatible


### PR DESCRIPTION
after this change, when I enter docker shell and check to see if aws-cli is installed. I get this message:

```
root@conductor-dev:/go# aws --version
aws-cli/1.16.247 Python/3.7.3 Linux/4.9.184-linuxkit botocore/1.12.237
```


which is the same it was before python3 upgard, suggesting nothing should be broken.



this is what it was before:

```
root@conductor-dev:/go# aws --version
aws-cli/1.16.247 Python/2.7.16 Linux/4.9.184-linuxkit botocore/1.12.237
```