### PR TITLE
Get dockerSetup.sh to work on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ git clone https://github.com/Nextdoor/conductor.git
 ### Simple Deployment of Conductor on Dev Environment
 
 1. On your terminal `cd $GOPATH/src/conductor/conductor`
-2. Create a client and OAuth token from you git login by going to `https://github.com/settings/developers`. Create a `New OAuth App`. Set Application Name to `conductor`.  Homepage URL to `github.com/Nextdoor/conductor`.  And Authorized callback URL to your local dev URL for now `http://localhost/api/auth/login`
-3. Now, set the client id created in step above, in the `OAUTH_PAYLOAD` varialbe in `frontend/envfile` of your downloaded source code. 
+2. Create a client and OAuth token from you git login by going to `https://github.com/settings/developers`. Create a `New OAuth App`. Set Application Name to `conductor`.  Homepage URL to `https://github.com/Nextdoor/conductor`.  And Authorized callback URL to your local dev URL for now `http://localhost/api/auth/login`
+3. Now, set the client id created in step above, in the `OAUTH_PAYLOAD` variable in `frontend/envfile` of your downloaded source code.
 4. To create a conductor setup on a docker container , run `chmod +x ./dockerSetup.sh`, followed by `./dockerSetup.sh`
 5. To create a conductor setup on native mac , run `chmod +x ./nativeMacSetup.sh`, followed by `./nativeMacSetup.sh`
 6. In either case, your docker service is now accessible through your browser on `localhost:80`

--- a/dockerSetup.sh
+++ b/dockerSetup.sh
@@ -8,7 +8,7 @@ PINK='\033[0;35m'
 NC='\033[0m'        # No Color
 
 echo -e "${PINK}checking install of package management tools..${NC}"
-if ! brew ls --versions yarn; then brew install yarn; fi; 
+if which brew && ! brew ls --versions yarn; then brew install yarn; fi;
 
 echo -e "${PINK}stop all existing containers to avoid attached port conflicts..${NC}"
 docker container stop $(docker container ls -aq)
@@ -25,8 +25,10 @@ make test-data
 echo -e "${PINK}building react.js and frontend static files webpack into resources/frontend...${NC}"
 make prod-compile -C frontend
 
+if pgrep nginx; then
 echo -e "${PINK} Stop potential running ngnix (from nativeMacSetup) to avoid port conflict...${NC}"
 sudo nginx -s stop
+fi
 
 echo -e "${PINK}building backend conductor service...${NC}"
 export POSTGRES_HOST=conductor-postgres

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,5 +1,6 @@
 all: watch
 
+SHELL := /bin/bash
 ENVFILE = if [ -e envfile ]; then set -a; source envfile; fi;
 install:
 	yarn install


### PR DESCRIPTION
`frontend/Makefile` change required to get envfile `source` to work:
https://stackoverflow.com/a/43566158/61410

Small typo in readme and github requires the https on the homepage URL.

![conductor_ubuntu](https://user-images.githubusercontent.com/86152/66021144-70350780-e49e-11e9-8215-adb4775bf476.png)

Now I just need to figure out how to create a train! Please advise!