### PR TITLE
change B.E. logic that doesn't allow claim on non latest train or closed trains

### DIFF
--- a/core/train.go
+++ b/core/train.go
@@ -462,15 +462,7 @@ func changeEngineer(r *http.Request) response {
 		return *resp
 	}
 
-	resp = validateMutableTrain(train)
-	if resp != nil {
-		return *resp
-	}
-
 	loggedUser := r.Context().Value("user").(*types.User)
-	if train.Closed {
-		return errorResponse("Train already closed.", http.StatusBadRequest)
-	}
 
 	err := dataClient.ChangeTrainEngineer(train, loggedUser)
 	if err != nil {


### PR DESCRIPTION
Now we wouldn't see any errors like-

'Train already closed'
'Train %d is not the latest train.'
'Train already deployed.'
'Train is deploying.'

When claiming engineer role

see #54 